### PR TITLE
Fix firewall port check pattern

### DIFF
--- a/dogwatch.sh
+++ b/dogwatch.sh
@@ -343,7 +343,7 @@ firewall_allows_ports() {
     local status
     status="$(ufw status | tr '[:upper:]' '[:lower:]')"
     for p in $ports; do
-      if echo "$status" | grep -qE "\\b$ p/tcp\\b.*allow|\\b$ p\\b.*allow"; then
+      if echo "$status" | grep -qE "\\b${p}/tcp\\b.*allow|\\b${p}\\b.*allow"; then
         : # permitido
       else
         # não temos certeza; marcamos como potencialmente bloqueado


### PR DESCRIPTION
## Summary
- correct UFW port detection by properly interpolating port variable in firewall check

## Testing
- `./dogwatch.sh status` *(fails: ss: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb072a8dc832bb50c1659e55a393d