### PR TITLE
fix(service): correct systemd restart directives

### DIFF
--- a/dogwatch.service
+++ b/dogwatch.service
@@ -7,7 +7,8 @@ Wants=network-online.target
 [Service]
 Type=simple
 ExecStart=/opt/dogwatch/dogwatch.sh daemon
-Restart=alwaysRestartSec=5
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure DogWatch systemd unit uses proper Restart directives

## Testing
- `bash -n dogwatch.sh`
- `systemd-analyze verify dogwatch.service` *(fails: Command /opt/dogwatch/dogwatch.sh is not executable)*

------
https://chatgpt.com/codex/tasks/task_e_689bb2650c40832b9c43cc071f2deccf