### PR TITLE
Accept manual network changes when connectivity remains healthy

### DIFF
--- a/dogwatch.service
+++ b/dogwatch.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DogWatch daemon
-After=network-online.target
+After=network.target
+StartLimitIntervalSec=0
 
 Wants=network-online.target
 
@@ -8,7 +9,7 @@ Wants=network-online.target
 Type=simple
 ExecStart=/opt/dogwatch/dogwatch.sh daemon
 Restart=always
-RestartSec=5
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- log and accept manual configuration changes only when connectivity is intact
- speed up dogwatch service restarts to re-run checks ASAP
- bump dogwatch version to 1.1.2

## Testing
- `bash -n dogwatch.sh`
- `bash dogwatch.sh status`


------
https://chatgpt.com/codex/tasks/task_e_689bbcbb47f0832bba8f2eac41b77fa7