### PR TITLE
feat: improve remote access recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Logs: `/var/log/dogwatch/dogwatch.log`
 - **Monitoramento a cada 5 min**: `normal | external | internal`.
   - **external** (falha do provedor/rota): **não altera** o sistema.
   - **internal** (mudança local): **restauração automática** do snapshot mais novo → mais antigo (inclui 0.0), validando conexão após cada passo.
+- **Verifica acesso remoto** ao IP público e reverte para backups caso falhe, mesmo com internet disponível.
 - **Garante portas**: `22` e **`16309`** sempre abertas; detecta firewalls instalados e abre portas necessárias automaticamente.
 - **Recuperação SSH**: habilita login por senha de qualquer IP, limpa blacklists e desbloqueia usuários para restabelecer acesso.
 - **Menu interativo**: execute `dogwatch.sh` sem argumentos para backups, restauração, portas, firewalls, listas (UFW), diagnósticos, speedtest, editar config, etc.

--- a/config.env.example
+++ b/config.env.example
@@ -33,3 +33,5 @@ NC_BIN="$(command -v nc || echo /usr/bin/nc)"
 JQ_BIN="$(command -v jq || echo /usr/bin/jq)"
 RSYNC_BIN="$(command -v rsync || echo /usr/bin/rsync)"
 SYSCTL_BIN="$(command -v sysctl || echo /usr/sbin/sysctl)"
+# Serviço usado para obter o IP público
+PUBLIC_IP_SERVICE="https://ifconfig.me"

--- a/dogwatch.service
+++ b/dogwatch.service
@@ -2,6 +2,7 @@
 Description=DogWatch daemon
 After=network.target
 StartLimitIntervalSec=0
+StartLimitBurst=0
 
 Wants=network-online.target
 


### PR DESCRIPTION
## Summary
- check remote access via public IP before accepting configuration
- restore from backups when remote access fails despite internet
- document and expose PUBLIC_IP_SERVICE
- make systemd service restart unlimited times

## Testing
- `bash -n dogwatch.sh`
- `apt-get update` (fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)
- `apt-get install -y shellcheck` (fails: Unable to locate package shellcheck)


------
https://chatgpt.com/codex/tasks/task_e_689bd2053558832ba732a5e9ed356a4a