### PR TITLE
Add reboot delay and adjust port requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Logs: `/var/log/dogwatch/dogwatch.log`
   - **external** (falha do provedor/rota): **não altera** o sistema.
   - **internal** (mudança local): **restauração automática** do snapshot mais novo → mais antigo (inclui 0.0), validando conexão após cada passo.
 - **Verifica acesso remoto** ao IP público e reverte para backups caso falhe, mesmo com internet disponível.
-- **Garante portas**: `22` e **`16309`** sempre abertas; detecta firewalls instalados e abre portas necessárias automaticamente.
+- **Garante portas**: `22` (obrigatória) e abre `16309` (opcional); detecta firewalls instalados e abre portas necessárias automaticamente.
 - **Recuperação SSH**: habilita login por senha de qualquer IP, limpa blacklists e desbloqueia usuários para restabelecer acesso.
 - **Menu interativo**: execute `dogwatch.sh` sem argumentos para backups, restauração, portas, firewalls, listas (UFW), diagnósticos, speedtest, editar config, etc.
 

--- a/config.env.example
+++ b/config.env.example
@@ -2,9 +2,9 @@
 # Editável em: /etc/dogwatch/config.env  (será criado/atualizado pelo install)
 #
 # Portas que DEVEM estar sempre abertas (espaço separado)
-MANDATORY_OPEN_PORTS="22 16309"
+MANDATORY_OPEN_PORTS="22"
 # Portas extras a monitorar (TCP)
-EXTRA_PORTS=""
+EXTRA_PORTS="16309"
 # Interface(s) preferenciais de rede (vazio = autodetect)
 PREFERRED_INTERFACES=""
 # Comandos/URLs para testar internet (saída)


### PR DESCRIPTION
## Summary
- add 20 second wait before rebooting during snapshot restore
- make SSH port 22 the only mandatory port and treat 16309 as optional
- update defaults and docs to reflect port handling

## Testing
- `bash -n dogwatch.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689c7c671f1c832ba19067b76117d225