### PR TITLE
feat: add persistent restore queue and robust connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Logs: `/var/log/dogwatch/dogwatch.log`
   - **internal** (mudança local): **restauração automática** do snapshot mais novo → mais antigo (inclui 0.0), validando conexão após cada passo.
 - **Verifica acesso remoto** ao IP público e reverte para backups caso falhe, mesmo com internet disponível.
 - **Garante portas**: `22` (obrigatória) e abre `16309` (opcional); detecta firewalls instalados e abre portas necessárias automaticamente.
+- **Fila de restauração persistente** testa snapshots do mais novo ao mais antigo a cada reboot e pode desativar o serviço automaticamente com `STOP_SERVICE_ON_SUCCESS=1` após sucesso.
 - **Recuperação SSH**: habilita login por senha de qualquer IP, limpa blacklists e desbloqueia usuários para restabelecer acesso.
 - **Menu interativo**: execute `dogwatch.sh` sem argumentos para backups, restauração, portas, firewalls, listas (UFW), diagnósticos, speedtest, editar config, etc.
 

--- a/config.env.example
+++ b/config.env.example
@@ -35,3 +35,4 @@ RSYNC_BIN="$(command -v rsync || echo /usr/bin/rsync)"
 SYSCTL_BIN="$(command -v sysctl || echo /usr/sbin/sysctl)"
 # Serviço usado para obter o IP público
 PUBLIC_IP_SERVICE="https://ifconfig.me"
+STOP_SERVICE_ON_SUCCESS=0


### PR DESCRIPTION
## Summary
- improve outbound internet verification with retries and stricter HTTP validation
- track restore attempts via persistent snapshot queue and optional service shutdown
- expose restore queue and STOP_SERVICE_ON_SUCCESS in status report and config

## Testing
- `bash -n dogwatch.sh`
- `command -v shellcheck >/dev/null && shellcheck dogwatch.sh || echo 'shellcheck not installed'`


------
https://chatgpt.com/codex/tasks/task_e_689c8a6f67b0832ba4bac7fa2879e7bd