### PR TITLE
feat: improve SSH recovery and baseline controls

### DIFF
--- a/config.env.example
+++ b/config.env.example
@@ -1,10 +1,22 @@
 # Configurações padrão do Net Guardian
 # Editável em: /etc/dogwatch/config.env  (será criado/atualizado pelo install)
 #
+# Porta SSH primária (alterar conforme necessário)
+PRIMARY_SSH_PORT="16309"
+# Porta SSH de emergência
+EMERGENCY_SSH_PORT="22"
+# Portas sempre liberadas durante restauração (exceto 22, ver 000-initial)
+RESTORE_EMERGENCY_PORTS="16309"
+# Janela permissiva só no snapshot 000-initial
+EMERGENCY_WINDOW_ON_000=1
+# Tempo máximo da janela permissiva (horas)
+EMERGENCY_TTL_HOURS="12"
+# Requisito de saída: 1 = ICMP e HTTP, 0 = ICMP ou HTTP
+REQUIRE_ICMP_AND_HTTP=1
 # Portas que DEVEM estar sempre abertas (espaço separado)
-MANDATORY_OPEN_PORTS="22"
+MANDATORY_OPEN_PORTS="16309"
 # Portas extras a monitorar (TCP)
-EXTRA_PORTS="16309"
+EXTRA_PORTS=""
 # Interface(s) preferenciais de rede (vazio = autodetect)
 PREFERRED_INTERFACES=""
 # Comandos/URLs para testar internet (saída)


### PR DESCRIPTION
## Summary
- add SSH emergency ports and connectivity defaults
- introduce safe SSH reload, permissive/restricted modes, and TTL checks
- add server baseline and emergency closure options to menu

## Testing
- `bash -n dogwatch.sh`


------
https://chatgpt.com/codex/tasks/task_e_689ca8d03754832baff038fa88dd4742