### PR TITLE
Add public remote requirement and degraded state

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Logs: `/var/log/dogwatch/dogwatch.log`
 
 ## Principais funcionalidades
 - **Backup 0.0 (imutável)** na primeira execução + **backups a cada 30 min**, mantendo **10** (além do 0.0).
-- **Monitoramento a cada 5 min**: `normal | external | internal`.
+- **Monitoramento a cada 5 min**: `normal | external | internal | degradado`.
   - **external** (falha do provedor/rota): **não altera** o sistema.
   - **internal** (mudança local): **restauração automática** do snapshot mais novo → mais antigo (inclui 0.0), validando conexão após cada passo.
+  - **degradado** (fallback para IP local; possível hairpin NAT): **restauração automática**.
 - **Verifica acesso remoto** ao IP público e reverte para backups caso falhe, mesmo com internet disponível.
 - **Garante portas**: `22` (obrigatória) e abre `16309` (opcional); detecta firewalls instalados e abre portas necessárias automaticamente.
 - **Fila de restauração persistente** testa snapshots do mais novo ao mais antigo a cada reboot e pode desativar o serviço automaticamente com `STOP_SERVICE_ON_SUCCESS=1` após sucesso.

--- a/config.env.example
+++ b/config.env.example
@@ -13,6 +13,8 @@ EMERGENCY_WINDOW_ON_000=1
 EMERGENCY_TTL_HOURS="12"
 # Requisito de saída: 1 = ICMP e HTTP, 0 = ICMP ou HTTP
 REQUIRE_ICMP_AND_HTTP=1
+# Exigir sucesso no teste remoto público (1 = obrigatório)
+REQUIRE_PUBLIC_REMOTE=0
 # Portas que DEVEM estar sempre abertas (espaço separado)
 MANDATORY_OPEN_PORTS="16309"
 # Portas extras a monitorar (TCP)


### PR DESCRIPTION
## Summary
- add REQUIRE_PUBLIC_REMOTE flag to enforce public IP checks
- mark remote access as degraded when only local fallback succeeds, with warning log
- handle new `degradado` state throughout status reports and monitoring

## Testing
- `bash -n dogwatch.sh`
- `shellcheck dogwatch.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689caf4cf670832b83bff9474d0673e2