### PR TITLE
Force package reinstall on failure

### DIFF
--- a/dogwatch.sh
+++ b/dogwatch.sh
@@ -141,7 +141,12 @@ install_self() {
     local pkgs=("$@")
     local attempt=0
     while (( attempt < 2 )); do
-      if DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${pkgs[@]}" >/dev/null; then
+      local args=(install -y --no-install-recommends)
+      if (( attempt == 1 )); then
+        args+=(--reinstall)
+        log DEBUG "Forçando reinstalação de pacotes: ${pkgs[*]}"
+      fi
+      if DEBIAN_FRONTEND=noninteractive apt-get "${args[@]}" "${pkgs[@]}" >/dev/null; then
         return 0
       fi
       attempt=$((attempt+1))


### PR DESCRIPTION
## Summary
- Ensure dogwatch installer retries with package reinstallation on failure

## Testing
- `bash -n dogwatch.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_689cb8e47690832ba11912b666744596