### PR TITLE
Improve DogWatch firewall and SSH handling

### DIFF
--- a/dogwatch.service
+++ b/dogwatch.service
@@ -1,16 +1,15 @@
 [Unit]
 Description=DogWatch daemon
-After=network.target
+Wants=network-online.target
+After=network-online.target
 StartLimitIntervalSec=0
 StartLimitBurst=0
-
-Wants=network-online.target
 
 [Service]
 Type=simple
 ExecStart=/opt/dogwatch/dogwatch.sh daemon
 Restart=always
-RestartSec=1
+RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- make listening checks more robust and fix UFW parsing
- configure SSH ports and fail2ban during installation
- start service on install and ensure SSH before monitoring

## Testing
- `bash -n dogwatch.sh`
- `bash -n install.sh`
- `bash dogwatch.sh status` *(fails: Acesso remoto: FALHA - possível IP/porta incorreta)*

------
https://chatgpt.com/codex/tasks/task_e_689cc4f2591c832b90d2772b8e3850a4