### PR TITLE
Remove virtualization abort in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,8 +20,7 @@ main() {
   local virt
   virt="$(systemd-detect-virt 2>/dev/null || echo unknown)"
   if [[ "$virt" != "none" ]]; then
-    echo "[dogwatch] Ambiente virtual detectado ($virt); instalação abortada."
-    exit 1
+    echo "[dogwatch] Aviso: ambiente virtual detectado ($virt); prosseguindo com a instalação..."
   fi
   apt-get update -y || true
   DEBIAN_FRONTEND=noninteractive apt-get install -y git curl ca-certificates || true


### PR DESCRIPTION
## Summary
- Allow installation to proceed even when a virtual environment is detected

## Testing
- `bash -n install.sh`
- `shellcheck install.sh` *(fails: command not found; package install failed)*

------
https://chatgpt.com/codex/tasks/task_e_689cc7b1a6c8832b9eea9c518bde28c2