### PR TITLE
Improve SSH handling and daemon resilience

### DIFF
--- a/dogwatch.service
+++ b/dogwatch.service
@@ -1,15 +1,14 @@
 [Unit]
 Description=DogWatch daemon
 Wants=network-online.target
-After=network-online.target
-StartLimitIntervalSec=0
-StartLimitBurst=0
+After=network-online.target ssh.service
 
 [Service]
 Type=simple
 ExecStart=/opt/dogwatch/dogwatch.sh daemon
 Restart=always
-RestartSec=2
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
## Summary
- Harden sshd include to survive Match sections and ensure config directory exists
- Validate dual-port mode, retry binding, and improve nftables firewall checks
- Make installer and daemon virtualization-aware, update service unit, and expose repair command

## Testing
- `bash -n dogwatch.sh`
- `shellcheck dogwatch.sh` *(fails: command not found; attempted apt install but repositories unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_689cef84d780832ba15dc6fd4a49ce6d