### PR TITLE
Corrige configuração SSH e parâmetros de usuário

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ sudo systemctl restart dogwatch.service
 
 Se você usou o **one-liner**, repita o comando acima (ele baixa a última versão e reinstala).
 
+> **Dica**: se atualizar manualmente o binário `/opt/dogwatch/dogwatch.sh`, reinicie o serviço com
+> `sudo systemctl restart dogwatch` para que a nova versão seja carregada e evitar mensagens antigas.
+
 ## Remoção (mantém backups)
 ```bash
 sudo /opt/dogwatch/dogwatch.sh uninstall

--- a/config.env.example
+++ b/config.env.example
@@ -5,6 +5,8 @@
 PRIMARY_SSH_PORT="16309"
 # Porta SSH de emergência
 EMERGENCY_SSH_PORT="22"
+# Usuários permitidos no modo restrito (separados por espaço)
+ALLOW_USERS="aasn"
 # Portas sempre liberadas durante restauração (exceto 22, ver 000-initial)
 RESTORE_EMERGENCY_PORTS="16309"
 # Janela permissiva só no snapshot 000-initial

--- a/dogwatch.sh
+++ b/dogwatch.sh
@@ -93,6 +93,7 @@ load_env() {
   export LOG_LEVEL="${LOG_LEVEL:-INFO}"
   export PRIMARY_SSH_PORT="${PRIMARY_SSH_PORT:-16309}"
   export EMERGENCY_SSH_PORT="${EMERGENCY_SSH_PORT:-22}"
+  export ALLOW_USERS="${ALLOW_USERS:-aasn}"
   export RESTORE_EMERGENCY_PORTS="${RESTORE_EMERGENCY_PORTS:-16309}"
   export EMERGENCY_WINDOW_ON_000="${EMERGENCY_WINDOW_ON_000:-1}"
   export REQUIRE_ICMP_AND_HTTP="${REQUIRE_ICMP_AND_HTTP:-1}"
@@ -801,11 +802,11 @@ Port $PRIMARY_SSH_PORT
 Port $EMERGENCY_SSH_PORT
 PasswordAuthentication yes
 PermitRootLogin yes
+AddressFamily any
+ListenAddress 0.0.0.0
+ListenAddress ::
 EOF
   chmod 0644 /etc/ssh/sshd_config.d/99-dogwatch.conf
-
-  printf "\nAddressFamily any\nListenAddress 0.0.0.0\nListenAddress ::\n" \
-    >> /etc/ssh/sshd_config.d/99-dogwatch.conf
 
   ssh_safe_reload || true
   sleep 1
@@ -845,8 +846,8 @@ ssh_set_restricted_mode() {
 Port $PRIMARY_SSH_PORT
 PasswordAuthentication yes
 PermitRootLogin no
-AllowUsers aasn
 EOF
+  [[ -n "${ALLOW_USERS:-}" ]] && echo "AllowUsers $ALLOW_USERS" >> /etc/ssh/sshd_config.d/99-dogwatch.conf
   ssh_safe_reload || true
   for fw in $FIREWALLS; do
     case "$fw" in


### PR DESCRIPTION
## Summary
- Permite definir usuários permitidos no modo restrito via `ALLOW_USERS`
- Reescreve configuração SSH de duas portas com binds amplos
- Documenta reinício do serviço após atualização manual

## Testing
- `bash -n dogwatch.sh`
- `shellcheck dogwatch.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfdf39150832b9570dc4ad73eb618