### PR TITLE
Atualiza docs e arquivos de suporte do DogWatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,14 +8,14 @@ uninstall:
 	sudo /opt/dogwatch/dogwatch.sh uninstall || true
 
 enable:
-	sudo systemctl enable --now dogwatch.service
+	sudo systemctl enable --now dogwatch.service dogwatch-safelane.service
 
 disable:
-	sudo systemctl disable --now dogwatch.service || true
-	sudo systemctl stop dogwatch.service || true
+	sudo systemctl disable --now dogwatch.service dogwatch-safelane.service || true
+	sudo systemctl stop dogwatch.service dogwatch-safelane.service || true
 
 status:
-	systemctl status dogwatch.service --no-pager || true
+	systemctl status --no-pager dogwatch.service dogwatch-safelane.service || true
 	sudo /opt/dogwatch/dogwatch.sh status || true
 
 logs:

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ sudo apt-get update -y && sudo apt-get install -y git
 git clone https://github.com/aryabdo/DogWatch.git
 cd DogWatch
 sudo ./install.sh
-sudo systemctl enable --now dogwatch.service
+# O instalador já habilita os serviços dogwatch e dogwatch-safelane
 ```
 
 ## Instalação (one-liner via `curl`)
-> Substitua `<seu-usuario>` e `<dogwatch>` pelo nome do seu repositório público no GitHub.
-
 ```bash
-curl -fsSL https://raw.githubusercontent.com/aryabdo/DogWatch/main/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/aryabdo/DogWatch/main/install.sh | \
+  sudo REPO_URL=https://github.com/aryabdo/DogWatch.git bash
 ```
 
 ## Atualização
@@ -46,7 +45,8 @@ sudo /opt/dogwatch/dogwatch.sh uninstall
 
 ## Componentes
 - `dogwatch.sh` — Daemon + CLI/menu.
-- `dogwatch.service` — Serviço systemd (inicia no boot; reinicia se cair).
+- `dogwatch.service` — Serviço systemd principal (inicia no boot; reinicia se cair).
+- `dogwatch-safelane.service` — Serviço systemd que abre portas essenciais antes da rede (gerado pelo install.sh).
 - `config.env.example` — Exemplo copiado para `/etc/dogwatch/config.env` na instalação; ajuste depois conforme necessário.
 - `install.sh` — Instalador que pode instalar a partir deste repositório ou via one-liner.
 - `Makefile` — Atalhos (install/uninstall/menu/status/logs/pkg).
@@ -63,7 +63,7 @@ Logs: `/var/log/dogwatch/dogwatch.log`
   - **internal** (mudança local): **restauração automática** do snapshot mais novo → mais antigo (inclui 0.0), validando conexão após cada passo.
   - **degradado** (fallback para IP local; possível hairpin NAT): **restauração automática**.
 - **Verifica acesso remoto** ao IP público e reverte para backups caso falhe, mesmo com internet disponível.
-- **Garante portas**: `22` (obrigatória) e abre `16309` (opcional); detecta firewalls instalados e abre portas necessárias automaticamente.
+- **Garante portas**: `16309` (primária) e `22` (emergência); detecta firewalls instalados e abre portas necessárias automaticamente.
 - **Fila de restauração persistente** testa snapshots do mais novo ao mais antigo a cada reboot e pode desativar o serviço automaticamente com `STOP_SERVICE_ON_SUCCESS=1` após sucesso.
 - **Recuperação SSH**: habilita login por senha de qualquer IP, limpa blacklists e desbloqueia usuários para restabelecer acesso.
 - **Menu interativo**: execute `dogwatch.sh` sem argumentos para backups, restauração, portas, firewalls, listas (UFW), diagnósticos, speedtest, editar config, etc.

--- a/config.env.example
+++ b/config.env.example
@@ -1,4 +1,4 @@
-# Configurações padrão do Net Guardian
+# Configurações padrão do DogWatch
 # Editável em: /etc/dogwatch/config.env  (será criado/atualizado pelo install)
 #
 # Porta SSH primária (alterar conforme necessário)
@@ -52,3 +52,31 @@ SYSCTL_BIN="$(command -v sysctl || echo /usr/sbin/sysctl)"
 # Serviço usado para obter o IP público
 PUBLIC_IP_SERVICE="https://ifconfig.me"
 STOP_SERVICE_ON_SUCCESS=0
+
+# Promover pendências após N ciclos normais
+PENDING_STABLE_CYCLES=2
+# Exigir conectividade saudável antes de salvar pendência
+STRICT_PENDING_CONNECTIVITY=1
+
+# Tentativas/intervalos para aplicar regras de firewall
+FIREWALL_APPLY_RETRIES=10
+FIREWALL_APPLY_INTERVAL=1
+# Forçar uso de apenas um firewall (ex.: ufw)
+ENFORCE_SINGLE_FIREWALL="ufw"
+# Segurar firewalld para evitar conflitos
+HOLD_FIREWALLD=1
+# Opções de acesso SSH
+SSH_PERMIT_ROOT="no"
+SSH_PASSWORD_AUTH="no"
+# Reparo somente remoto
+REMOTE_ONLY_REPAIR=1
+REMOTE_ONLY_REPAIR_CYCLES=3
+# Reboot automático após restauração bem-sucedida
+RESTORE_AUTO_REBOOT=1
+
+# Restauração automática de IP fixo
+AUTO_RESTORE_FIXED_IP=1
+FIXED_IP_RESTORE_MIN_INTERVAL=900
+NETPLAN_RESTORE_REVERT_SECONDS=180
+# Monitorar interface específica (vazio = padrão)
+INTERFACE_WATCH=""

--- a/dogwatch.service
+++ b/dogwatch.service
@@ -1,13 +1,14 @@
 [Unit]
 Description=DogWatch daemon
+After=network-online.target
 Wants=network-online.target
-After=network-online.target ssh.service
 
 [Service]
 Type=simple
 ExecStart=/opt/dogwatch/dogwatch.sh daemon
 Restart=always
-RestartSec=5
+RestartSec=3
+User=root
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Resumo
- Documenta ativação automática dos serviços e corrige comando one-liner com `REPO_URL`
- Adiciona `dogwatch-safelane.service` aos componentes e Makefile
- Expande `config.env.example` com novas variáveis de firewall, SSH e restauração

## Testes
- `bash -n install.sh dogwatch.sh`


------
https://chatgpt.com/codex/tasks/task_e_689e670e69a0832bb7cb7a9f085cb154